### PR TITLE
Add key codes for ErgoDox KC_MPRV and KC_MNXT

### DIFF
--- a/src/classes/CCApplication.m
+++ b/src/classes/CCApplication.m
@@ -21,11 +21,13 @@
 					break;
 				
 				case NX_KEYTYPE_FAST:
+				case NX_KEYTYPE_NEXT:
 					cr = system("cmus-remote -n");
 					ALog(@"%d %d %d %d  Next", keyCode, keyState, keyIsRepeat, cr);
 					break;
 				
 				case NX_KEYTYPE_REWIND:
+				case NX_KEYTYPE_PREVIOUS:
 					cr = system("cmus-remote -r");
 					ALog(@"%d %d %d %d  Previous", keyCode, keyState, keyIsRepeat, cr);
 					break;


### PR DESCRIPTION
Hi Christian,

I found one more issue with those magic keys. Looks like OS X treats REWIND/FF keys in a special way.
[My ErgoDox keyboard](https://github.com/jackhumbert/qmk_firmware/pull/258) cannot send the same key codes as Apple keyboards.

[I have tried to change key codes for these keys on ErgoDox](https://github.com/jackhumbert/qmk_firmware/issues/293). Didn't help. So I made this workaround for `cmus-control`. Quick and dirty.

Feel free to rewrite or reject it. I understand this is a very rare case.

Thank you!
